### PR TITLE
Change the config list values to use `defineListAllowEmpty` to stop them from being corrected into non-existance

### DIFF
--- a/src/main/java/com/davenonymous/riddlechests/config/CommonConfig.java
+++ b/src/main/java/com/davenonymous/riddlechests/config/CommonConfig.java
@@ -16,8 +16,8 @@ public class CommonConfig {
 
 	public static ForgeConfigSpec.IntValue ADDITIONAL_CHARS;
 	public static ForgeConfigSpec.DoubleValue CHANCE_TO_REPLACE_CHEST;
-	public static ForgeConfigSpec.ConfigValue<List<String>> NEVER_REPLACE_LOOTTABLES;
-	public static ForgeConfigSpec.ConfigValue<List<String>> DISABLE_RIDDLE_CATEGORIES;
+	public static ForgeConfigSpec.ConfigValue<List<? extends String>> NEVER_REPLACE_LOOTTABLES;
+	public static ForgeConfigSpec.ConfigValue<List<? extends String>> DISABLE_RIDDLE_CATEGORIES;
 
 	public static void register() {
 		COMMON_BUILDER.comment("General Settings").push(CATEGORY_GENERAL);
@@ -39,11 +39,11 @@ public class CommonConfig {
 
 		NEVER_REPLACE_LOOTTABLES = b
 				.comment("Never replace vanilla chests that have one of these loot tables assigned")
-				.define("loottableBlacklist", Arrays.asList("minecraft:chests/shipwreck_map", "minecraft:chests/spawn_bonus_chest"), o -> true);
+				.defineListAllowEmpty(List.of("loottableBlacklist"), () -> Arrays.asList("minecraft:chests/shipwreck_map", "minecraft:chests/spawn_bonus_chest"), o -> true);
 
 		DISABLE_RIDDLE_CATEGORIES = b
 				.comment("Categories listed here will not be loaded. Add 'riddlechests:betrayal_at_krondor' to disable the built in riddles. Make sure to have at least one loaded category!")
-				.define("disableCategories", Arrays.asList(""), o -> true);
+				.defineListAllowEmpty(List.of("disableCategories"), () -> Arrays.asList(""), o -> true);
 	}
 
 }


### PR DESCRIPTION
Currently due to the use of the regular `define` method which isn't build for lists the config options get nuked when checked if the configs are correct.
Due to the list values being erased it'll remake the config every time you load the mod.

So currently when you boot up the mod the config will look like [this (Pastebin)](https://pastebin.com/D0JXfd2A)

After applying the fixes from this PR it looks like [this (Pastebin)](https://pastebin.com/HVLz1JT1)

(This issue is also in the 1.18.1 version)